### PR TITLE
fix: probe primary.load() before calling it (dsh 0.1.2-alpha.1)

### DIFF
--- a/lib/client-ui.js
+++ b/lib/client-ui.js
@@ -275,7 +275,8 @@ function createCompatScope(options) {
     load: async () => {
       fallbackStarted = true;
       await fallback?.load();
-      await primary.load();
+      const withLoad = primary;
+      if (typeof withLoad.load === "function") await withLoad.load();
     },
     // The batch surface exists only while the bridge controller is the active
     // transport; the official scope path still writes per-field. A getter

--- a/src/client-ui/compat-scope.ts
+++ b/src/client-ui/compat-scope.ts
@@ -375,9 +375,15 @@ export function createCompatScope<T>(options: CompatScopeOptions<T>): CompatSett
     load: async () => {
       fallbackStarted = true;
       await fallback?.load();
-      // The official controller carries load() at runtime; the contract type
-      // omits it, so the call is made through the narrowed face.
-      await (primary as SettingsScope<T> & { load(): Promise<void> }).load();
+      // The official controller carried load() at runtime through 0.1.1-rc.2,
+      // where the contract type omitted it and the call went through a
+      // narrowed face. On 0.1.2-alpha.1 it is gone from the runtime too, so
+      // the cast describes nothing and calling it throws. Probe instead:
+      // bind() already triggers mirror.ensure() and the controller publishes
+      // through subscribe(), so skipping the explicit refresh loses nothing
+      // on hosts that no longer expose it.
+      const withLoad = primary as SettingsScope<T> & { load?(): Promise<void> };
+      if (typeof withLoad.load === "function") await withLoad.load();
     },
     // The batch surface exists only while the bridge controller is the active
     // transport; the official scope path still writes per-field. A getter


### PR DESCRIPTION
Fixes #3.

## Problem

On `dsh 0.1.2-alpha.1`, `createCompatScope` throws:

```
TypeError: primary.load is not a function
```

`src/client-ui/compat-scope.ts` reached `load()` on the official scope through a narrowed cast, with the comment noting the contract type omitted it but the runtime carried it. That held through `0.1.1-rc.2`. On `0.1.2-alpha.1` the method is gone from the runtime too — `SettingsScope<T>` is now exactly `getSnapshot` / `subscribe` / `mutate` / `set` / `unset` — so the cast describes nothing and the call throws.

The rejection is uncaught, so it tears the client tree down and neighbouring plugins lose their UI. I found it because a voice plugin's microphone button kept vanishing a few seconds after activation; the trigger was actually a `settings/document-updated` event reaching `client-ui.tsx:363`, which is why it looked unrelated.

## Fix

Probe before calling:

```ts
const withLoad = primary as SettingsScope<T> & { load?(): Promise<void> };
if (typeof withLoad.load === "function") await withLoad.load();
```

`rc` hosts keep the explicit refresh. Newer hosts skip it and lose nothing: `SettingsScopeBinder.bind()` already triggers `mirror.ensure()` inside a `ctx.effect`, and the controller publishes through `subscribe()`, which `createCompatScope` is already wired to.

`fallback?.load()` is untouched — `BridgeScopeController` implements `load()` itself.

One guard covers all three call sites, since they all go through the object `createCompatScope` returns:

- `client-ui.tsx:363` — `settings/document-updated`
- `client-ui.tsx:369` — `connection/reset`
- `client-ui.tsx:472` — after the settings form saves

## Verification

Built with `npm run build` (both `tsc` passes clean) and installed into a live `0.1.2-alpha.1` web profile:

- Plugin activates — `dsh-openviking` present in `__DSH_BOOT__.entries`, no "Failed to load plugins" banner
- No `TypeError` in the browser console across load, hard reload, and ~20s of interaction
- The neighbouring plugin's UI survives; before the patch it disappeared within ~5s

`node --test test/*.test.mjs`: **58 passing, 1 failing**. The failure is `memadd resolves local paths...` with `ERR_INVALID_FILE_URL_PATH` in `lib/tools.js`. I confirmed it fails identically on unpatched `main` on Windows, so it is pre-existing and unrelated to this change.

I have not tested on an `rc` host — I do not have one. That path is unchanged in behaviour by construction (the probe succeeds and calls exactly what it called before), but it is untested by me.

## Note for docs

Worth flagging for anyone hitting this: `disabled: true` in the profile patch layer does not stop it. The browser bundle is assembled from installed packages declaring `dsh.client`, not from enabled loader entries, so the client half keeps running until the package is actually removed. Chrome also caches the combined bundle aggressively — a hard reload is needed to see the change.
